### PR TITLE
Fixed issue #3: Incomplete Dependency Array in the useMemo hook insid…

### DIFF
--- a/src/components/DailyForecast.jsx
+++ b/src/components/DailyForecast.jsx
@@ -23,7 +23,7 @@ const DailyForecast = ({ timeSeries, userTimezone, weatherCodeMap }) => {
             ).pop();
             return { ...day, minTemp, maxTemp, dominantCode };
         });
-    }, [timeSeries]);
+    }, [timeSeries, userTimezone]);
 
     return (
         <Card>


### PR DESCRIPTION
# The Problem
The useMemo hook had an incomplete dependency array. The function in the useMemo hook was using [userTimezone] on lines 9 and 11 where it calls [dayjs(curr.time).tz(userTimezone)], but [userTimezone] wasn't included in the dependency array.

# The Solution
Add [userTimezone] to the dependency array, changing it from:
```
}, [timeSeries]);
```
to:
```
}, [timeSeries, userTimezone]);
```