### PR TITLE
Fixing issues #7 and #8

### DIFF
--- a/src/components/ui/WeatherIcon.jsx
+++ b/src/components/ui/WeatherIcon.jsx
@@ -1,3 +1,5 @@
+import { HelpCircle } from 'lucide-react';
+
 const WeatherIcon = ({ weatherCodeMap, code, className = '', ...props }) => {
     const { icon: IconComponent, color } = weatherCodeMap[code] || { icon: HelpCircle, color: 'text-gray-400' };
     return <IconComponent className={`${color} ${className}`} {...props} />

--- a/src/services/WeatherServicesClient.js
+++ b/src/services/WeatherServicesClient.js
@@ -178,7 +178,7 @@ class MetOfficeClient {
                     const delay = Math.pow(2, attempt) * 1000;
                     await new Promise(resolve => setTimeout(resolve, delay));
                 } else {
-                    throw new Error("ERROR: Failed to retrieve forecast after multiple attempts.");
+                    throw new Error("ERROR: Failed to retrieve forecast after multiple attempts." + ` Attempt ${attempt + 1} failed with error: ${error.message}`);
                 }
             }
         }
@@ -221,7 +221,7 @@ class MetOfficeClient {
                     const delay = Math.pow(2, attempt) * 1000;
                     await new Promise(resolve => setTimeout(resolve, delay));
                 } else {
-                    throw new Error("ERROR: Failed to retrieve forecast after multiple attempts.");
+                    throw new Error("ERROR: Failed to retrieve forecast after multiple attempts." + ` Attempt ${attempt + 1} failed with error: ${error.message}`);
                 }
             }
         }


### PR DESCRIPTION
# Issue #7 fix
Included the required top-level HellpCircle import
```bash
import { HelpCircle } from 'lucide-react';
```

# Issue #8 
Expanded the error message returned by the catch blocks to include the specific error returned by the last failed attempt.
```bash
            } catch (error) {
                if (attempt < retries - 1) {
                    // Exponential backoff: wait 2^attempt seconds
                    const delay = Math.pow(2, attempt) * 1000;
                    await new Promise(resolve => setTimeout(resolve, delay));
                } else {
                    throw new Error("ERROR: Failed to retrieve forecast after multiple attempts." + ` Attempt ${attempt + 1} failed with error: ${error.message}`);
                }
            }
```

